### PR TITLE
Patch 2

### DIFF
--- a/src/Events/AfterImport.php
+++ b/src/Events/AfterImport.php
@@ -47,6 +47,6 @@ class AfterImport extends Event
      */
     public function getDelegate()
     {
-        return $this->reader;
+        return $this->reader->getPhpSpreadsheetReader();
     }
 }

--- a/src/Events/BeforeImport.php
+++ b/src/Events/BeforeImport.php
@@ -47,6 +47,6 @@ class BeforeImport extends Event
      */
     public function getDelegate()
     {
-        return $this->reader;
+        return $this->reader->getPhpSpreadsheetReader();
     }
 }


### PR DESCRIPTION


### Requirements

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [ x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [ ] Added tests to ensure against regression.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, 
the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->
### Based on the Documentation:

"Both Reader and Sheet have a ->getDelegate() method which returns the underlying PhpSpreadsheet class. This will allow you to add custom macros as shortcuts to PhpSpreadsheet methods that are not available in this package."

Please confirm if It applies to other Events. _(Same change proposed for AfterImport at the moment)_

Reader.php returns 
- a Workbook Object when calling getDelegate()
- a IReader Object when calling getPhpSpreadsheetReader()

### Why Should This Be Added?

<!-- Explain why this functionality should be added in Laravel-Excel -->


### Benefits

<!-- What benefits will be realized by the code change? -->

Use the getDelegate() as a standard to obtain the phpSpreadsheet Object as defined in Reader.php
This could avoid confusion in the use of the two different methods that return the same object.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts (e.g. breaking changes) of the code change? -->

At the moment it is unknown for me how many implementations use **getDelegate** instead of **getReader**  in the Events\BeforeImport.php and Events\AfterImport.php.

```php
   /**
     * @return Reader
     */
    public function getReader(): Reader
    {
        return $this->reader;
    }

    /**
     * @return mixed
     */
    public function getDelegate()
    {
        return $this->reader;
    }
```

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

-->

```php

    public static function beforeImport(BeforeImport $event)
   {
        echo 'Before Import ' . '<br>';
        /*
         * Access the phpSpreadsheet class - getDelegate()
        */
        dd($event->getDelegate());


```


Result: 

```
Xlsx {#280 ▼
  -referenceHelper: ReferenceHelper {#279}
  #readDataOnly: true
  #readEmptyCells: true
  #includeCharts: false
  #loadSheetsOnly: array:2 [▶]
  #readFilter: DefaultReadFilter {#271}
  #fileHandle: null
  #securityScanner: XmlScanner {#291 ▶}
}

```


### Applicable Issues

<!-- Enter any applicable Issues here -->
